### PR TITLE
Add Windows 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Alternatively: this repository can be **cloned** and linked to the `scripts/addo
 - Linux system and `ffmpeg`.
 
 ### Installing ffmpeg on Windows
-- Follow the "Add to path" part here(and reboot): http://blog.gregzaal.com/how-to-install-ffmpeg-on-windows/ 
+- Follow the "Add to path" section here (and reboot): http://blog.gregzaal.com/how-to-install-ffmpeg-on-windows/ 

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Alternatively: this repository can be **cloned** and linked to the `scripts/addo
 - Linux system and `ffmpeg`.
 
 ### Installing ffmpeg on Windows
-- Follow the "Add to path" part here: http://blog.gregzaal.com/how-to-install-ffmpeg-on-windows/ 
+- Follow the "Add to path" part here(and reboot): http://blog.gregzaal.com/how-to-install-ffmpeg-on-windows/ 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Alternatively: this repository can be **cloned** and linked to the `scripts/addo
 ### Requirements
 - Blender 2.83 or later.
 - Linux system and `ffmpeg`.
+
+### Installing ffmpeeg on Windows
+- Follow the "Add to path" part here: http://blog.gregzaal.com/how-to-install-ffmpeg-on-windows/ 

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ Alternatively: this repository can be **cloned** and linked to the `scripts/addo
 - Blender 2.83 or later.
 - Linux system and `ffmpeg`.
 
-### Installing ffmpeeg on Windows
+### Installing ffmpeg on Windows
 - Follow the "Add to path" part here: http://blog.gregzaal.com/how-to-install-ffmpeg-on-windows/ 

--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,7 @@ from bpy.props import BoolProperty, StringProperty, EnumProperty
 
 log = logging.getLogger(__name__)
 os_platform = platform.system()  # 'Linux', 'Darwin', 'Java', 'Windows'
-supported_platforms = {'Linux', 'Darwin', 'Windows'}
+supported_platforms = {"Linux", "Darwin", "Windows"}
 
 
 # Audio Device Configuration #######################################################################
@@ -56,11 +56,11 @@ supported_platforms = {'Linux', 'Darwin', 'Windows'}
 
 def get_audio_devices_list_linux():
     """Get list of audio devices on Linux."""
-    sound_cards = ['default']
+    sound_cards = ["default"]
     with subprocess.Popen(args=["arecord", "-L"], stdout=subprocess.PIPE) as proc:
         arecord_output = proc.stdout.read()
         for line in arecord_output.splitlines():
-            line = line.decode('utf-8')
+            line = line.decode("utf-8")
             # Skip indented lines, search only for PCM names
             # TODO: show only names which are likely to be an input device
             if line.startswith(tuple(w for w in whitespace)) == False:
@@ -75,25 +75,25 @@ def get_audio_devices_list_darwin():
     args = shlex.split(ffmpeg_command)
 
     av_devices = []
-    with subprocess.Popen(args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+    with subprocess.Popen(
+        args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ) as proc:
         command_output = proc.stderr.read()
         for line in command_output.splitlines():
-            line = line.decode('utf-8')
+            line = line.decode("utf-8")
             if line.startswith("[AVFoundation"):
                 av_devices.append(line)
-
     # Strip video devices from list
     include_entries = False
     for device in av_devices:
-        if 'AVFoundation video devices:' in device:
+        if "AVFoundation video devices:" in device:
             include_entries = False
-        if 'AVFoundation audio devices:' in device:
+        if "AVFoundation audio devices:" in device:
             include_entries = True
         # Depending whether we are in the "audio devices" part of the
         # list, include entries or not
         if include_entries:
             sound_cards.append(device)
-
     # Remove ffmpeg list heading "AVFoundation audio devices:" since we
     # only need the subsequent items.
     sound_cards.pop(0)
@@ -102,8 +102,8 @@ def get_audio_devices_list_darwin():
     # [AVFoundation input device @ 0x7f9c0a604340] [0] Unknown USB Audio Device
     # to:
     # Unknown USB Audio Device"
-    pattern = r'\[.*?\]'
-    sound_cards = [re.sub(pattern, '', sound_card) for sound_card in sound_cards]
+    pattern = r"\[.*?\]"
+    sound_cards = [re.sub(pattern, "", sound_card) for sound_card in sound_cards]
     # Important: we assume that the device number (e.g. [0]) matches the order
     # of the device in the list. This is used to build the ffmpeg command in
     # the start_recording function.
@@ -117,17 +117,20 @@ def get_audio_devices_list_windows():
     args = shlex.split(ffmpeg_command)
 
     av_devices = []
-    with subprocess.Popen(args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+    with subprocess.Popen(
+        args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ) as proc:
         command_output = proc.stderr.read()
         audio_found = False
         for line in command_output.splitlines():
-            line = line.decode('utf-8')
-            if audio_found and not "Alternative name" in line and line !="":
+            line = line.decode("utf-8")
+            if audio_found and not "Alternative name" in line and line != "":
                 if chr(34) in line:
-                    sound_cards.append(line[line.find(chr(34))+1:line.rfind(chr(34))])
+                    sound_cards.append(
+                        line[line.find(chr(34)) + 1 : line.rfind(chr(34))]
+                    )
             if "DirectShow audio devices" in line:
                 audio_found = True
-
     return sound_cards
 
 
@@ -136,7 +139,6 @@ def populate_enum_items_for_sound_devices(self, context):
 
     if os_platform not in supported_platforms:
         return []
-
     # Re-use the existing enum values if they weren't generated too long ago.
     # Note: this generate function is called often, on draw of the UI element
     # that renders the enum property and per each enum item when the dropdown
@@ -151,27 +153,24 @@ def populate_enum_items_for_sound_devices(self, context):
     except AttributeError:
         # First time that the enum is being generated.
         pass
-
     log.debug("Polling system sound cards to update audio input drop-down")
 
     # Detect existing sound cards and devices
-    if os_platform == 'Linux':
+    if os_platform == "Linux":
         sound_cards = get_audio_devices_list_linux()
-    elif os_platform == 'Darwin':
+    elif os_platform == "Darwin":
         sound_cards = get_audio_devices_list_darwin()
-    elif os_platform == 'Windows':
+    elif os_platform == "Windows":
         sound_cards = get_audio_devices_list_windows()
     else:
         sound_cards = []
-
     # Generate items to show in the enum dropdown
     enum_items = []
     for idx, sound_card in enumerate(sound_cards):
         enum_value = sound_card
-        if os_platform == 'Darwin':
+        if os_platform == "Darwin":
             enum_value = f"{idx}"
         enum_items.append((enum_value, sound_card, sound_card))
-
     # Update the cached enum items and the generation timestamp
     populate_enum_items_for_sound_devices.enum_items = enum_items
     populate_enum_items_for_sound_devices.last_executed = time.time()
@@ -192,11 +191,11 @@ def save_sound_card_preference(self, context):
 
     log.debug(f"Set audio input preference to '{audio_device}' for {os_platform}")
 
-    if os_platform == 'Linux':
+    if os_platform == "Linux":
         addon_prefs.audio_device_linux = audio_device
-    elif os_platform == 'Darwin':
+    elif os_platform == "Darwin":
         addon_prefs.audio_device_darwin = audio_device
-    elif os_platform == 'Windows':
+    elif os_platform == "Windows":
         addon_prefs.audio_device_windows = audio_device
 
 
@@ -207,7 +206,7 @@ class SEQUENCER_OT_push_to_talk(Operator):
     bl_idname = "sequencer.push_to_talk"
     bl_label = "Start Recording"
     bl_description = "Add a sound strip with audio recorded from the microphone"
-    bl_options = {'UNDO', 'REGISTER'}
+    bl_options = {"UNDO", "REGISTER"}
 
     # Runtime state shared between instances of this operator
     should_stop = False
@@ -228,7 +227,7 @@ class SEQUENCER_OT_push_to_talk(Operator):
 
         strip = scene.sequence_editor.sequences.new_effect(
             name="Recording...",
-            type='COLOR',
+            type="COLOR",
             channel=1,
             frame_start=self.frame_start,
             frame_end=self.frame_start + 1,
@@ -242,8 +241,8 @@ class SEQUENCER_OT_push_to_talk(Operator):
         # This operator is available only in the sequencer area of the
         # sequence editor.
         return (
-            context.space_data.type == 'SEQUENCE_EDITOR'
-            and context.space_data.view_type == 'SEQUENCER'
+            context.space_data.type == "SEQUENCE_EDITOR"
+            and context.space_data.view_type == "SEQUENCER"
         )
 
     def generate_filename(self, context) -> bool:
@@ -261,27 +260,24 @@ class SEQUENCER_OT_push_to_talk(Operator):
                 )
             else:
                 reason = "directory to save the sound clips does not exist"
-            self.report({'ERROR'}, f"Could not record audio: {reason}")
+            self.report({"ERROR"}, f"Could not record audio: {reason}")
             return False
-
         if not os.access(sounds_dir, os.W_OK):
             self.report(
-                {'ERROR'},
+                {"ERROR"},
                 "Could not record audio: the directory to save the sound clips is not writable",
             )
             return False
-
         timestamp = datetime.datetime.now().strftime("_%Y-%m-%d_%H-%M-%S")
 
         self.filepath = f"{sounds_dir}{filename}{timestamp}.wav"
 
         if os.path.exists(self.filepath):
             self.report(
-                {'ERROR'},
+                {"ERROR"},
                 "Could not record audio: a file already exists where the sound clip would be saved",
             )
             return False
-
         return True
 
     def start_recording(self, context) -> bool:
@@ -290,31 +286,28 @@ class SEQUENCER_OT_push_to_talk(Operator):
         addon_prefs = context.preferences.addons[__name__].preferences
 
         framerate = context.scene.render.fps
-        if os_platform == 'Linux':
+        if os_platform == "Linux":
             audio_input_device = addon_prefs.audio_device_linux
             ffmpeg_command = (
                 f"ffmpeg -fflags nobuffer -f alsa "
                 f'-i "{audio_input_device}" '
                 f"-framerate {framerate} {self.filepath}"
             )
-        elif os_platform == 'Darwin':
+        elif os_platform == "Darwin":
             ffmpeg_command = (
                 f"ffmpeg -f avfoundation "
                 f'-i ":{addon_prefs.audio_device_darwin}" '
                 f"-framerate {framerate} {self.filepath}"
             )
-        elif os_platform == 'Windows':
-            filepath = chr(34)+(self.filepath)+chr(34)#.replace(chr(92), chr(92)+chr(92))+chr(34)
+        elif os_platform == "Windows":
+            filepath = chr(34) + (self.filepath) + chr(34)
             ffmpeg_command = (
                 f"ffmpeg -f dshow "
-                #f'-i ":{addon_prefs.audio_device_windows}" '         
-                f'-i audio="Microphone (Realtek(R) Audio)" '
+                f'-i audio="{addon_prefs.audio_device_windows}" '
                 f"-framerate {framerate} {filepath}"
             )
-            print(ffmpeg_command)
         else:
             raise RuntimeError("os_platform %s not supported" % os_platform)
-
         args = shlex.split(ffmpeg_command)
         self.recording_process = subprocess.Popen(args)
 
@@ -331,46 +324,40 @@ class SEQUENCER_OT_push_to_talk(Operator):
         # instance will listen to in order to terminate.
         if SEQUENCER_OT_push_to_talk.is_running:
             SEQUENCER_OT_push_to_talk.should_stop = True
-            return {'FINISHED'}
-
+            return {"FINISHED"}
         SEQUENCER_OT_push_to_talk.is_running = True
 
         # Generate the name to save the audio file.
         if not self.generate_filename(context):
             SEQUENCER_OT_push_to_talk.is_running = False
-            return {'CANCELLED'}
-
+            return {"CANCELLED"}
         if not self.start_recording(context):
             SEQUENCER_OT_push_to_talk.is_running = False
-            return {'CANCELLED'}
-
+            return {"CANCELLED"}
         self.add_visual_feedback_strip(context)
 
         # Ensure that the timeline is playing
         self.was_playing = context.screen.is_animation_playing
         if not self.was_playing:
             bpy.ops.screen.animation_play()
-
         # Start this operator as modal
         wm = context.window_manager
         self._timer = wm.event_timer_add(0.02, window=context.window)
         wm.modal_handler_add(self)
-        return {'RUNNING_MODAL'}
+        return {"RUNNING_MODAL"}
 
     def modal(self, context, event):
         """Periodic update to draw and check if this operator should stop."""
 
         # Cancel. Delete the current recording.
-        if event.type in {'ESC'}:
+        if event.type in {"ESC"}:
             self.cancel(context)
-            return {'CANCELLED'}
-
+            return {"CANCELLED"}
         # Confirm. Create a strip with the current recording.
-        if event.type in {'RET'}:
+        if event.type in {"RET"}:
             return self.execute(context)
-
         # Periodic update
-        if event.type == 'TIMER':
+        if event.type == "TIMER":
 
             # Listen for signal to stop
             if SEQUENCER_OT_push_to_talk.should_stop:
@@ -382,14 +369,12 @@ class SEQUENCER_OT_push_to_talk(Operator):
             # Stop if the timeline looped around
             if context.scene.frame_current < self.frame_start:
                 return self.execute(context)
-
             # Draw
             color_strip = self.visual_feedback_strip
             color_strip.frame_final_end = context.scene.frame_current
-
         # Don't consume the input, otherwise it is impossible to click the
         # stop button.
-        return {'PASS_THROUGH'}
+        return {"PASS_THROUGH"}
 
     def on_cancel_or_finish(self, context):
         """Called when this operator is finishing (confirm) or got canceled."""
@@ -397,12 +382,10 @@ class SEQUENCER_OT_push_to_talk(Operator):
         # Finish the sound recording process.
         if self.recording_process:
             self.recording_process.terminate()
-
         # Unregister from the periodic modal calls.
         if self._timer:
             wm = context.window_manager
             wm.event_timer_remove(self._timer)
-
         # Update this operator's state.
         SEQUENCER_OT_push_to_talk.is_running = False
         SEQUENCER_OT_push_to_talk.should_stop = False
@@ -431,12 +414,13 @@ class SEQUENCER_OT_push_to_talk(Operator):
             channel = color_strip.channel
             frame_start = color_strip.frame_final_start
             sequence_ed.sequences.remove(color_strip)
-
         # Create a new sound strip in the place of the dummy strip.
         name = addon_prefs.prefix
-        sound_strip = sequence_ed.sequences.new_sound(name, self.filepath, channel, frame_start)
+        sound_strip = sequence_ed.sequences.new_sound(
+            name, self.filepath, channel, frame_start
+        )
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     def cancel(self, context):
         """Cleanup temporary state if canceling during modal execution."""
@@ -460,26 +444,30 @@ def draw_push_to_talk_button(self, context):
     layout = self.layout
     layout.enabled = os_platform in supported_platforms
 
+    layout.separator_spacer()
+
     if SEQUENCER_OT_push_to_talk.is_running:
         # 'SNAP_FACE' is used because it looks like 'STOP', which was removed.
-        layout.operator("sequencer.push_to_talk", text="Stop Recording", icon='SNAP_FACE')
+        layout.operator(
+            "sequencer.push_to_talk", text="Stop Recording", icon="SNAP_FACE"
+        )
     else:
-        layout.operator("sequencer.push_to_talk", text="Start Recording", icon='REC')
+        layout.operator("sequencer.push_to_talk", text="Start Recording", icon="REC")
 
 
 class SEQUENCER_PT_push_to_talk(Panel):
     bl_label = "Configuration"
     bl_category = "Push To Talk"
-    bl_space_type = 'SEQUENCE_EDITOR'
-    bl_region_type = 'UI'
+    bl_space_type = "SEQUENCE_EDITOR"
+    bl_region_type = "UI"
 
     @classmethod
     def poll(cls, context):
         # Show this panel only in the sequence editor in the right-side panel
         # of the sequencer area (not on the preview area).
         return (
-            context.space_data.type == 'SEQUENCE_EDITOR'
-            and context.space_data.view_type == 'SEQUENCER'
+            context.space_data.type == "SEQUENCE_EDITOR"
+            and context.space_data.view_type == "SEQUENCER"
         )
 
     def draw(self, context):
@@ -488,9 +476,10 @@ class SEQUENCER_PT_push_to_talk(Panel):
         layout.use_property_decorate = False
 
         if os_platform not in supported_platforms:
-            layout.label(text=f"Recording on {os_platform} is not supported", icon='ERROR')
+            layout.label(
+                text=f"Recording on {os_platform} is not supported", icon="ERROR"
+            )
             return
-
         addon_prefs = context.preferences.addons[__name__].preferences
 
         col = layout.column()
@@ -500,17 +489,18 @@ class SEQUENCER_PT_push_to_talk(Panel):
         col.separator()
         col.prop(addon_prefs, "audio_input_device")
         # DEBUG
-        if os_platform == 'Darwin':
-            col.prop(addon_prefs, "audio_device_darwin", text="(Debug)")
-        if os_platform == 'Windows':
-            col.prop(addon_prefs, "audio_device_windows", text="(Debug)")
+        #        if os_platform == 'Darwin':
+        #            col.prop(addon_prefs, "audio_device_darwin", text="(Debug)")
+        #        if os_platform == 'Windows':
+        #            col.prop(addon_prefs, "audio_device_windows", text="(Debug)")
         # Show a save button for the user preferences if they aren't
         # automatically saved.
         prefs = context.preferences
         if not prefs.use_preferences_save:
             col.separator()
             col.operator(
-                "wm.save_userpref", text=f"Save Preferences{' *' if prefs.is_dirty else ''}",
+                "wm.save_userpref",
+                text=f"Save Preferences{' *' if prefs.is_dirty else ''}",
             )
 
 
@@ -551,7 +541,7 @@ class SEQUENCER_PushToTalk_Preferences(AddonPreferences):
         items=populate_enum_items_for_sound_devices,
         name="Sound Card",
         description="Sound card to be used, from the ones found on this computer",
-        options={'SKIP_SAVE'},
+        options={"SKIP_SAVE"},
         update=save_sound_card_preference,
     )
 
@@ -570,21 +560,19 @@ def register():
 
     for cls in classes:
         bpy.utils.register_class(cls)
-
     bpy.types.SEQUENCER_HT_header.append(draw_push_to_talk_button)
 
     # Sync system detected audio devices with the saved preferences
     addon_prefs = bpy.context.preferences.addons[__name__].preferences
     audio_input_devices = {
-        'Linux': addon_prefs.audio_device_linux,
-        'Darwin': addon_prefs.audio_device_darwin,
-        'Windows': addon_prefs.audio_device_windows,
+        "Linux": addon_prefs.audio_device_linux,
+        "Darwin": addon_prefs.audio_device_darwin,
+        "Windows": addon_prefs.audio_device_windows,
     }
     if audio_input_devices[os_platform] not in addon_prefs.audio_input_device:
         audio_input_devices[os_platform] = "default"
     else:
         addon_prefs.audio_input_device = audio_input_devices[os_platform]
-
     log.debug("-----------------Done Registering---------------------------------")
 
 
@@ -596,7 +584,6 @@ def unregister():
 
     for cls in classes:
         bpy.utils.unregister_class(cls)
-
     log.debug("-----------------Done Unregistering--------------------------------")
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -306,10 +306,13 @@ class SEQUENCER_OT_push_to_talk(Operator):
         elif os_platform == 'Windows':
             filepath = chr(34)+(self.filepath)+chr(34)
             ffmpeg_command = (
-                f"ffmpeg -f dshow "
+                f"ffmpeg -f dshow " #-ac 1 -ar 48000 -f s16le -acodec pcm_s16le 
+                #f"-audio_buffer_size 80 " # Use a audio buffer size of 50 ms
                 f'-i audio="{addon_prefs.audio_device_windows}" '
-                f"-framerate {framerate} {filepath}"
+                f"-ar 48000 -framerate {framerate} "
+                f"{filepath}"
             )
+            print(ffmpeg_command)
         else:
             raise RuntimeError("os_platform %s not supported" % os_platform)
 
@@ -458,8 +461,6 @@ def draw_push_to_talk_button(self, context):
     layout = self.layout
     layout.enabled = os_platform in supported_platforms
 
-    layout.separator_spacer()
-
     if SEQUENCER_OT_push_to_talk.is_running:
         # 'SNAP_FACE' is used because it looks like 'STOP', which was removed.
         layout.operator("sequencer.push_to_talk", text="Stop Recording", icon='SNAP_FACE')
@@ -500,10 +501,10 @@ class SEQUENCER_PT_push_to_talk(Panel):
         col.separator()
         col.prop(addon_prefs, "audio_input_device")
         # DEBUG
-#        if os_platform == 'Darwin':
-#            col.prop(addon_prefs, "audio_device_darwin", text="(Debug)")
-#        if os_platform == 'Windows':
-#            col.prop(addon_prefs, "audio_device_windows", text="(Debug)")
+        # if os_platform == 'Darwin':
+           # col.prop(addon_prefs, "audio_device_darwin", text="(Debug)")
+        # if os_platform == 'Windows':
+           # col.prop(addon_prefs, "audio_device_windows", text="(Debug)")
         # Show a save button for the user preferences if they aren't
         # automatically saved.
         prefs = context.preferences

--- a/__init__.py
+++ b/__init__.py
@@ -119,27 +119,34 @@ def get_audio_devices_list_windows():
     av_devices = []
     with subprocess.Popen(args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
         command_output = proc.stderr.read()
+        audio_found = False
         for line in command_output.splitlines():
             line = line.decode('utf-8')
-            print(line)
-            if line.startswith("[dshow input"):
-                av_devices.append(line)
+            #print(line)
+            if audio_found and not "Alternative name" in line and line !="":
+                #print("adding: "+line[line.find(chr(34))+1:line.rfind(chr(34))])
+                #av_devices.append(line[line.find(chr(34))+1:line.rfind(chr(34))])
+                if chr(34) in line:
+                    sound_cards.append(line[line.find(chr(34))+1:line.rfind(chr(34))])
+            if "DirectShow audio devices" in line:
+                audio_found = True
+                #print("found: " + line)
 
     # Strip video devices from list
-    include_entries = False
-    for device in av_devices:
-        if 'DirectShow video devices' in device:
-            include_entries = False
-        if 'DirectShow audio devices' in device:
-            include_entries = True
-        # Depending whether we are in the "audio devices" part of the
-        # list, include entries or not
-        if include_entries:
-            sound_cards.append(device)
+#    include_entries = False
+#    for device in av_devices:
+#        if 'DirectShow video devices' in device:
+#            include_entries = False
+#        if 'DirectShow audio devices' in device:
+#            include_entries = True
+#        # Depending whether we are in the "audio devices" part of the
+#        # list, include entries or not
+#        if include_entries:
+#            sound_cards.append(device)
 
     # Remove ffmpeg list heading "AVFoundation audio devices:" since we
     # only need the subsequent items.
-    sound_cards.pop(0)
+    #sound_cards.pop(0)
 
     # Parse the remaining items so they go from:
     # [AVFoundation input device @ 0x7f9c0a604340] [0] Unknown USB Audio Device
@@ -150,6 +157,7 @@ def get_audio_devices_list_windows():
     # Important: we assume that the device number (e.g. [0]) matches the order
     # of the device in the list. This is used to build the ffmpeg command in
     # the start_recording function.
+    #print(sound_cards)
     return sound_cards
 
 
@@ -326,11 +334,14 @@ class SEQUENCER_OT_push_to_talk(Operator):
                 f"-framerate {framerate} {self.filepath}"
             )
         elif os_platform == 'Windows':
+            filepath = chr(34)+(self.filepath)+chr(34)#.replace(chr(92), chr(92)+chr(92))+chr(34)
             ffmpeg_command = (
                 f"ffmpeg -f dshow "
-                f'-i ":{addon_prefs.audio_device_windows}" '
-                f"-framerate {framerate} {self.filepath}"
+                #f'-i ":{addon_prefs.audio_device_windows}" '         
+                f'-i audio="Microphone (Realtek(R) Audio)" '
+                f"-framerate {framerate} {filepath}"
             )
+            print(ffmpeg_command)
         else:
             raise RuntimeError("os_platform %s not supported" % os_platform)
 

--- a/__init__.py
+++ b/__init__.py
@@ -79,7 +79,7 @@ def get_audio_devices_list_darwin():
         command_output = proc.stderr.read()
         for line in command_output.splitlines():
             line = line.decode('utf-8')
-            if line.startswith("[AVFoundation input"):
+            if line.startswith("[AVFoundation"):
                 av_devices.append(line)
 
     # Strip video devices from list
@@ -127,14 +127,6 @@ def get_audio_devices_list_windows():
                     sound_cards.append(line[line.find(chr(34))+1:line.rfind(chr(34))])
             if "DirectShow audio devices" in line:
                 audio_found = True
-
-    # Nessessary?
-    # Parse the remaining items so they go from:
-    # [AVFoundation input device @ 0x7f9c0a604340] [0] Unknown USB Audio Device
-    # to:
-    # Unknown USB Audio Device"
-    #pattern = r'\[.*?\]'
-    #sound_cards = [re.sub(pattern, '', sound_card) for sound_card in sound_cards]
 
     return sound_cards
 
@@ -315,7 +307,7 @@ class SEQUENCER_OT_push_to_talk(Operator):
             filepath = chr(34)+(self.filepath)+chr(34)#.replace(chr(92), chr(92)+chr(92))+chr(34)
             ffmpeg_command = (
                 f"ffmpeg -f dshow "
-                #f'-i ":{addon_prefs.audio_device_windows}" '
+                #f'-i ":{addon_prefs.audio_device_windows}" '         
                 f'-i audio="Microphone (Realtek(R) Audio)" '
                 f"-framerate {framerate} {filepath}"
             )

--- a/__init__.py
+++ b/__init__.py
@@ -122,42 +122,20 @@ def get_audio_devices_list_windows():
         audio_found = False
         for line in command_output.splitlines():
             line = line.decode('utf-8')
-            #print(line)
             if audio_found and not "Alternative name" in line and line !="":
-                #print("adding: "+line[line.find(chr(34))+1:line.rfind(chr(34))])
-                #av_devices.append(line[line.find(chr(34))+1:line.rfind(chr(34))])
                 if chr(34) in line:
                     sound_cards.append(line[line.find(chr(34))+1:line.rfind(chr(34))])
             if "DirectShow audio devices" in line:
                 audio_found = True
-                #print("found: " + line)
 
-    # Strip video devices from list
-#    include_entries = False
-#    for device in av_devices:
-#        if 'DirectShow video devices' in device:
-#            include_entries = False
-#        if 'DirectShow audio devices' in device:
-#            include_entries = True
-#        # Depending whether we are in the "audio devices" part of the
-#        # list, include entries or not
-#        if include_entries:
-#            sound_cards.append(device)
-
-    # Remove ffmpeg list heading "AVFoundation audio devices:" since we
-    # only need the subsequent items.
-    #sound_cards.pop(0)
-
+    # Nessessary?
     # Parse the remaining items so they go from:
     # [AVFoundation input device @ 0x7f9c0a604340] [0] Unknown USB Audio Device
     # to:
     # Unknown USB Audio Device"
-    pattern = r'\[.*?\]'
-    sound_cards = [re.sub(pattern, '', sound_card) for sound_card in sound_cards]
-    # Important: we assume that the device number (e.g. [0]) matches the order
-    # of the device in the list. This is used to build the ffmpeg command in
-    # the start_recording function.
-    #print(sound_cards)
+    #pattern = r'\[.*?\]'
+    #sound_cards = [re.sub(pattern, '', sound_card) for sound_card in sound_cards]
+
     return sound_cards
 
 
@@ -198,7 +176,7 @@ def populate_enum_items_for_sound_devices(self, context):
     enum_items = []
     for idx, sound_card in enumerate(sound_cards):
         enum_value = sound_card
-        if os_platform == 'Darwin' or os_platform == 'Windows' :
+        if os_platform == 'Darwin':
             enum_value = f"{idx}"
         enum_items.append((enum_value, sound_card, sound_card))
 
@@ -337,7 +315,7 @@ class SEQUENCER_OT_push_to_talk(Operator):
             filepath = chr(34)+(self.filepath)+chr(34)#.replace(chr(92), chr(92)+chr(92))+chr(34)
             ffmpeg_command = (
                 f"ffmpeg -f dshow "
-                #f'-i ":{addon_prefs.audio_device_windows}" '         
+                #f'-i ":{addon_prefs.audio_device_windows}" '
                 f'-i audio="Microphone (Realtek(R) Audio)" '
                 f"-framerate {framerate} {filepath}"
             )

--- a/__init__.py
+++ b/__init__.py
@@ -306,13 +306,11 @@ class SEQUENCER_OT_push_to_talk(Operator):
         elif os_platform == 'Windows':
             filepath = chr(34)+(self.filepath)+chr(34)
             ffmpeg_command = (
-                f"ffmpeg -f dshow " #-ac 1 -ar 48000 -f s16le -acodec pcm_s16le 
-                #f"-audio_buffer_size 80 " # Use a audio buffer size of 50 ms
+                f"ffmpeg -f dshow "
                 f'-i audio="{addon_prefs.audio_device_windows}" '
                 f"-ar 48000 -framerate {framerate} "
                 f"{filepath}"
             )
-            print(ffmpeg_command)
         else:
             raise RuntimeError("os_platform %s not supported" % os_platform)
 

--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,7 @@ from bpy.props import BoolProperty, StringProperty, EnumProperty
 
 log = logging.getLogger(__name__)
 os_platform = platform.system()  # 'Linux', 'Darwin', 'Java', 'Windows'
-supported_platforms = {"Linux", "Darwin", "Windows"}
+supported_platforms = {'Linux', 'Darwin', 'Windows'}
 
 
 # Audio Device Configuration #######################################################################
@@ -56,11 +56,11 @@ supported_platforms = {"Linux", "Darwin", "Windows"}
 
 def get_audio_devices_list_linux():
     """Get list of audio devices on Linux."""
-    sound_cards = ["default"]
+    sound_cards = ['default']
     with subprocess.Popen(args=["arecord", "-L"], stdout=subprocess.PIPE) as proc:
         arecord_output = proc.stdout.read()
         for line in arecord_output.splitlines():
-            line = line.decode("utf-8")
+            line = line.decode('utf-8')
             # Skip indented lines, search only for PCM names
             # TODO: show only names which are likely to be an input device
             if line.startswith(tuple(w for w in whitespace)) == False:
@@ -75,25 +75,25 @@ def get_audio_devices_list_darwin():
     args = shlex.split(ffmpeg_command)
 
     av_devices = []
-    with subprocess.Popen(
-        args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    ) as proc:
+    with subprocess.Popen(args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
         command_output = proc.stderr.read()
         for line in command_output.splitlines():
             line = line.decode('utf-8')
             if line.startswith("[AVFoundation"):
                 av_devices.append(line)
+
     # Strip video devices from list
     include_entries = False
     for device in av_devices:
-        if "AVFoundation video devices:" in device:
+        if 'AVFoundation video devices:' in device:
             include_entries = False
-        if "AVFoundation audio devices:" in device:
+        if 'AVFoundation audio devices:' in device:
             include_entries = True
         # Depending whether we are in the "audio devices" part of the
         # list, include entries or not
         if include_entries:
             sound_cards.append(device)
+
     # Remove ffmpeg list heading "AVFoundation audio devices:" since we
     # only need the subsequent items.
     sound_cards.pop(0)
@@ -102,8 +102,8 @@ def get_audio_devices_list_darwin():
     # [AVFoundation input device @ 0x7f9c0a604340] [0] Unknown USB Audio Device
     # to:
     # Unknown USB Audio Device"
-    pattern = r"\[.*?\]"
-    sound_cards = [re.sub(pattern, "", sound_card) for sound_card in sound_cards]
+    pattern = r'\[.*?\]'
+    sound_cards = [re.sub(pattern, '', sound_card) for sound_card in sound_cards]
     # Important: we assume that the device number (e.g. [0]) matches the order
     # of the device in the list. This is used to build the ffmpeg command in
     # the start_recording function.
@@ -117,20 +117,17 @@ def get_audio_devices_list_windows():
     args = shlex.split(ffmpeg_command)
 
     av_devices = []
-    with subprocess.Popen(
-        args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    ) as proc:
+    with subprocess.Popen(args=args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
         command_output = proc.stderr.read()
         audio_found = False
         for line in command_output.splitlines():
-            line = line.decode("utf-8")
-            if audio_found and not "Alternative name" in line and line != "":
+            line = line.decode('utf-8')
+            if audio_found and not "Alternative name" in line and line !="":
                 if chr(34) in line:
-                    sound_cards.append(
-                        line[line.find(chr(34)) + 1 : line.rfind(chr(34))]
-                    )
+                    sound_cards.append(line[line.find(chr(34))+1:line.rfind(chr(34))])
             if "DirectShow audio devices" in line:
                 audio_found = True
+
     return sound_cards
 
 
@@ -139,6 +136,7 @@ def populate_enum_items_for_sound_devices(self, context):
 
     if os_platform not in supported_platforms:
         return []
+
     # Re-use the existing enum values if they weren't generated too long ago.
     # Note: this generate function is called often, on draw of the UI element
     # that renders the enum property and per each enum item when the dropdown
@@ -153,24 +151,27 @@ def populate_enum_items_for_sound_devices(self, context):
     except AttributeError:
         # First time that the enum is being generated.
         pass
+
     log.debug("Polling system sound cards to update audio input drop-down")
 
     # Detect existing sound cards and devices
-    if os_platform == "Linux":
+    if os_platform == 'Linux':
         sound_cards = get_audio_devices_list_linux()
-    elif os_platform == "Darwin":
+    elif os_platform == 'Darwin':
         sound_cards = get_audio_devices_list_darwin()
-    elif os_platform == "Windows":
+    elif os_platform == 'Windows':
         sound_cards = get_audio_devices_list_windows()
     else:
         sound_cards = []
+
     # Generate items to show in the enum dropdown
     enum_items = []
     for idx, sound_card in enumerate(sound_cards):
         enum_value = sound_card
-        if os_platform == "Darwin":
+        if os_platform == 'Darwin':
             enum_value = f"{idx}"
         enum_items.append((enum_value, sound_card, sound_card))
+
     # Update the cached enum items and the generation timestamp
     populate_enum_items_for_sound_devices.enum_items = enum_items
     populate_enum_items_for_sound_devices.last_executed = time.time()
@@ -191,11 +192,11 @@ def save_sound_card_preference(self, context):
 
     log.debug(f"Set audio input preference to '{audio_device}' for {os_platform}")
 
-    if os_platform == "Linux":
+    if os_platform == 'Linux':
         addon_prefs.audio_device_linux = audio_device
-    elif os_platform == "Darwin":
+    elif os_platform == 'Darwin':
         addon_prefs.audio_device_darwin = audio_device
-    elif os_platform == "Windows":
+    elif os_platform == 'Windows':
         addon_prefs.audio_device_windows = audio_device
 
 
@@ -206,7 +207,7 @@ class SEQUENCER_OT_push_to_talk(Operator):
     bl_idname = "sequencer.push_to_talk"
     bl_label = "Start Recording"
     bl_description = "Add a sound strip with audio recorded from the microphone"
-    bl_options = {"UNDO", "REGISTER"}
+    bl_options = {'UNDO', 'REGISTER'}
 
     # Runtime state shared between instances of this operator
     should_stop = False
@@ -227,7 +228,7 @@ class SEQUENCER_OT_push_to_talk(Operator):
 
         strip = scene.sequence_editor.sequences.new_effect(
             name="Recording...",
-            type="COLOR",
+            type='COLOR',
             channel=1,
             frame_start=self.frame_start,
             frame_end=self.frame_start + 1,
@@ -241,8 +242,8 @@ class SEQUENCER_OT_push_to_talk(Operator):
         # This operator is available only in the sequencer area of the
         # sequence editor.
         return (
-            context.space_data.type == "SEQUENCE_EDITOR"
-            and context.space_data.view_type == "SEQUENCER"
+            context.space_data.type == 'SEQUENCE_EDITOR'
+            and context.space_data.view_type == 'SEQUENCER'
         )
 
     def generate_filename(self, context) -> bool:
@@ -260,24 +261,27 @@ class SEQUENCER_OT_push_to_talk(Operator):
                 )
             else:
                 reason = "directory to save the sound clips does not exist"
-            self.report({"ERROR"}, f"Could not record audio: {reason}")
+            self.report({'ERROR'}, f"Could not record audio: {reason}")
             return False
+
         if not os.access(sounds_dir, os.W_OK):
             self.report(
-                {"ERROR"},
+                {'ERROR'},
                 "Could not record audio: the directory to save the sound clips is not writable",
             )
             return False
+
         timestamp = datetime.datetime.now().strftime("_%Y-%m-%d_%H-%M-%S")
 
         self.filepath = f"{sounds_dir}{filename}{timestamp}.wav"
 
         if os.path.exists(self.filepath):
             self.report(
-                {"ERROR"},
+                {'ERROR'},
                 "Could not record audio: a file already exists where the sound clip would be saved",
             )
             return False
+
         return True
 
     def start_recording(self, context) -> bool:
@@ -286,21 +290,21 @@ class SEQUENCER_OT_push_to_talk(Operator):
         addon_prefs = context.preferences.addons[__name__].preferences
 
         framerate = context.scene.render.fps
-        if os_platform == "Linux":
+        if os_platform == 'Linux':
             audio_input_device = addon_prefs.audio_device_linux
             ffmpeg_command = (
                 f"ffmpeg -fflags nobuffer -f alsa "
                 f'-i "{audio_input_device}" '
                 f"-framerate {framerate} {self.filepath}"
             )
-        elif os_platform == "Darwin":
+        elif os_platform == 'Darwin':
             ffmpeg_command = (
                 f"ffmpeg -f avfoundation "
                 f'-i ":{addon_prefs.audio_device_darwin}" '
                 f"-framerate {framerate} {self.filepath}"
             )
-        elif os_platform == "Windows":
-            filepath = chr(34) + (self.filepath) + chr(34)
+        elif os_platform == 'Windows':
+            filepath = chr(34)+(self.filepath)+chr(34)
             ffmpeg_command = (
                 f"ffmpeg -f dshow "
                 f'-i audio="{addon_prefs.audio_device_windows}" '
@@ -308,6 +312,7 @@ class SEQUENCER_OT_push_to_talk(Operator):
             )
         else:
             raise RuntimeError("os_platform %s not supported" % os_platform)
+
         args = shlex.split(ffmpeg_command)
         self.recording_process = subprocess.Popen(args)
 
@@ -324,40 +329,46 @@ class SEQUENCER_OT_push_to_talk(Operator):
         # instance will listen to in order to terminate.
         if SEQUENCER_OT_push_to_talk.is_running:
             SEQUENCER_OT_push_to_talk.should_stop = True
-            return {"FINISHED"}
+            return {'FINISHED'}
+
         SEQUENCER_OT_push_to_talk.is_running = True
 
         # Generate the name to save the audio file.
         if not self.generate_filename(context):
             SEQUENCER_OT_push_to_talk.is_running = False
-            return {"CANCELLED"}
+            return {'CANCELLED'}
+
         if not self.start_recording(context):
             SEQUENCER_OT_push_to_talk.is_running = False
-            return {"CANCELLED"}
+            return {'CANCELLED'}
+
         self.add_visual_feedback_strip(context)
 
         # Ensure that the timeline is playing
         self.was_playing = context.screen.is_animation_playing
         if not self.was_playing:
             bpy.ops.screen.animation_play()
+
         # Start this operator as modal
         wm = context.window_manager
         self._timer = wm.event_timer_add(0.02, window=context.window)
         wm.modal_handler_add(self)
-        return {"RUNNING_MODAL"}
+        return {'RUNNING_MODAL'}
 
     def modal(self, context, event):
         """Periodic update to draw and check if this operator should stop."""
 
         # Cancel. Delete the current recording.
-        if event.type in {"ESC"}:
+        if event.type in {'ESC'}:
             self.cancel(context)
-            return {"CANCELLED"}
+            return {'CANCELLED'}
+
         # Confirm. Create a strip with the current recording.
-        if event.type in {"RET"}:
+        if event.type in {'RET'}:
             return self.execute(context)
+
         # Periodic update
-        if event.type == "TIMER":
+        if event.type == 'TIMER':
 
             # Listen for signal to stop
             if SEQUENCER_OT_push_to_talk.should_stop:
@@ -369,12 +380,14 @@ class SEQUENCER_OT_push_to_talk(Operator):
             # Stop if the timeline looped around
             if context.scene.frame_current < self.frame_start:
                 return self.execute(context)
+
             # Draw
             color_strip = self.visual_feedback_strip
             color_strip.frame_final_end = context.scene.frame_current
+
         # Don't consume the input, otherwise it is impossible to click the
         # stop button.
-        return {"PASS_THROUGH"}
+        return {'PASS_THROUGH'}
 
     def on_cancel_or_finish(self, context):
         """Called when this operator is finishing (confirm) or got canceled."""
@@ -382,10 +395,12 @@ class SEQUENCER_OT_push_to_talk(Operator):
         # Finish the sound recording process.
         if self.recording_process:
             self.recording_process.terminate()
+
         # Unregister from the periodic modal calls.
         if self._timer:
             wm = context.window_manager
             wm.event_timer_remove(self._timer)
+
         # Update this operator's state.
         SEQUENCER_OT_push_to_talk.is_running = False
         SEQUENCER_OT_push_to_talk.should_stop = False
@@ -414,13 +429,12 @@ class SEQUENCER_OT_push_to_talk(Operator):
             channel = color_strip.channel
             frame_start = color_strip.frame_final_start
             sequence_ed.sequences.remove(color_strip)
+
         # Create a new sound strip in the place of the dummy strip.
         name = addon_prefs.prefix
-        sound_strip = sequence_ed.sequences.new_sound(
-            name, self.filepath, channel, frame_start
-        )
+        sound_strip = sequence_ed.sequences.new_sound(name, self.filepath, channel, frame_start)
 
-        return {"FINISHED"}
+        return {'FINISHED'}
 
     def cancel(self, context):
         """Cleanup temporary state if canceling during modal execution."""
@@ -448,26 +462,24 @@ def draw_push_to_talk_button(self, context):
 
     if SEQUENCER_OT_push_to_talk.is_running:
         # 'SNAP_FACE' is used because it looks like 'STOP', which was removed.
-        layout.operator(
-            "sequencer.push_to_talk", text="Stop Recording", icon="SNAP_FACE"
-        )
+        layout.operator("sequencer.push_to_talk", text="Stop Recording", icon='SNAP_FACE')
     else:
-        layout.operator("sequencer.push_to_talk", text="Start Recording", icon="REC")
+        layout.operator("sequencer.push_to_talk", text="Start Recording", icon='REC')
 
 
 class SEQUENCER_PT_push_to_talk(Panel):
     bl_label = "Configuration"
     bl_category = "Push To Talk"
-    bl_space_type = "SEQUENCE_EDITOR"
-    bl_region_type = "UI"
+    bl_space_type = 'SEQUENCE_EDITOR'
+    bl_region_type = 'UI'
 
     @classmethod
     def poll(cls, context):
         # Show this panel only in the sequence editor in the right-side panel
         # of the sequencer area (not on the preview area).
         return (
-            context.space_data.type == "SEQUENCE_EDITOR"
-            and context.space_data.view_type == "SEQUENCER"
+            context.space_data.type == 'SEQUENCE_EDITOR'
+            and context.space_data.view_type == 'SEQUENCER'
         )
 
     def draw(self, context):
@@ -476,10 +488,9 @@ class SEQUENCER_PT_push_to_talk(Panel):
         layout.use_property_decorate = False
 
         if os_platform not in supported_platforms:
-            layout.label(
-                text=f"Recording on {os_platform} is not supported", icon="ERROR"
-            )
+            layout.label(text=f"Recording on {os_platform} is not supported", icon='ERROR')
             return
+
         addon_prefs = context.preferences.addons[__name__].preferences
 
         col = layout.column()
@@ -489,18 +500,17 @@ class SEQUENCER_PT_push_to_talk(Panel):
         col.separator()
         col.prop(addon_prefs, "audio_input_device")
         # DEBUG
-        #        if os_platform == 'Darwin':
-        #            col.prop(addon_prefs, "audio_device_darwin", text="(Debug)")
-        #        if os_platform == 'Windows':
-        #            col.prop(addon_prefs, "audio_device_windows", text="(Debug)")
+#        if os_platform == 'Darwin':
+#            col.prop(addon_prefs, "audio_device_darwin", text="(Debug)")
+#        if os_platform == 'Windows':
+#            col.prop(addon_prefs, "audio_device_windows", text="(Debug)")
         # Show a save button for the user preferences if they aren't
         # automatically saved.
         prefs = context.preferences
         if not prefs.use_preferences_save:
             col.separator()
             col.operator(
-                "wm.save_userpref",
-                text=f"Save Preferences{' *' if prefs.is_dirty else ''}",
+                "wm.save_userpref", text=f"Save Preferences{' *' if prefs.is_dirty else ''}",
             )
 
 
@@ -541,7 +551,7 @@ class SEQUENCER_PushToTalk_Preferences(AddonPreferences):
         items=populate_enum_items_for_sound_devices,
         name="Sound Card",
         description="Sound card to be used, from the ones found on this computer",
-        options={"SKIP_SAVE"},
+        options={'SKIP_SAVE'},
         update=save_sound_card_preference,
     )
 
@@ -560,19 +570,21 @@ def register():
 
     for cls in classes:
         bpy.utils.register_class(cls)
+
     bpy.types.SEQUENCER_HT_header.append(draw_push_to_talk_button)
 
     # Sync system detected audio devices with the saved preferences
     addon_prefs = bpy.context.preferences.addons[__name__].preferences
     audio_input_devices = {
-        "Linux": addon_prefs.audio_device_linux,
-        "Darwin": addon_prefs.audio_device_darwin,
-        "Windows": addon_prefs.audio_device_windows,
+        'Linux': addon_prefs.audio_device_linux,
+        'Darwin': addon_prefs.audio_device_darwin,
+        'Windows': addon_prefs.audio_device_windows,
     }
     if audio_input_devices[os_platform] not in addon_prefs.audio_input_device:
         audio_input_devices[os_platform] = "default"
     else:
         addon_prefs.audio_input_device = audio_input_devices[os_platform]
+
     log.debug("-----------------Done Registering---------------------------------")
 
 
@@ -584,6 +596,7 @@ def unregister():
 
     for cls in classes:
         bpy.utils.unregister_class(cls)
+
     log.debug("-----------------Done Unregistering--------------------------------")
 
 


### PR DESCRIPTION
Add support for Windows, however ffmpeg must be "installed" using the "Add to path" part here: http://blog.gregzaal.com/how-to-install-ffmpeg-on-windows/ 

This may be too much to ask of the users, and maybe a way to add a path to ffmpeg in the add-on preferences could be considered?