### PR TITLE
Add `arecord` linux requirement for Microphone detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ On Linux, it typically starts with `sysdefault` or `usb`.
 
 ![Recoding configuration panel UI](docs/panel.png)
 
+Note: For Audio input detection to work on linux, you need to have `arecord` available (see [Requirements](#requirements)).
+
 ## Installation
 
 1. Download this repository as ZIP file.
@@ -29,6 +31,7 @@ On Linux, it typically starts with `sysdefault` or `usb`.
 
 ### Requirements
 - **`ffmpeg`**. See [instructions for Windows](https://www.geeksforgeeks.org/how-to-install-ffmpeg-on-windows/).
+-  `arecord` (Linux only). On Arch you can install it via the `alsa-utils` package
 
 ### Compatibility
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note: For Audio input detection to work on linux, you need to have `arecord` ava
 
 ### Requirements
 - **`ffmpeg`**. See [instructions for Windows](https://www.geeksforgeeks.org/how-to-install-ffmpeg-on-windows/).
--  `arecord` (Linux only). On Arch you can install it via the `alsa-utils` package
+-  **`arecord`** (Linux only). On Arch you can install it via the `alsa-utils` package.
 
 ### Compatibility
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ On Linux, it typically starts with `sysdefault` or `usb`.
 
 ![Recoding configuration panel UI](docs/panel.png)
 
-Note: For Audio input detection to work on linux, you need to have `arecord` available (see [Requirements](#requirements)).
-
 ## Installation
 
 1. Download this repository as ZIP file.


### PR DESCRIPTION
On some modern Linux distributions the Alsa sound system and its tools are not installed anymore, as mostly pulseaudio is used.

However this plugin relies on `arecord` to detect microphones. `arecord` will still work fine even with pulseaudio, however it needs to be installed.

If it is not installed, push_to_talk will fail to detect any microphones.

I updated the documentation accordingly.